### PR TITLE
Better support to relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,23 @@ Simple test runner for [Bash][0].
 
 ## Installation
 
-Just download the file (preferably somewhere in your `$PATH`) and give it execution permissions:
+Just download the file (preferably somewhere in your `$PATH`) and give it
+execution permissions:
 
     $ curl https://raw.githubusercontent.com/campanda/bash-test/master/bash-test > /usr/local/bin/bash-test
     $ chmod +x /usr/local/bin/bash-test
 
 ## Usage
 
-Write test cases as [Shell Functions][1], starting with `test_`. Example:
+Write test cases as [Shell Functions][1], starting with `test_` and export the
+variable `SOURCE` with the relative path to the directory where your scripts
+are located.
+
+Example:
 
     #!/usr/bin/env bash
+
+    export SOURCE='../src'
 
     test_something() {
       echo "foo" | grep "bar"
@@ -25,6 +32,10 @@ Write test cases as [Shell Functions][1], starting with `test_`. Example:
 
     test_something_else() {
       test 2 -eq 2
+    }
+
+    test_my_script() {
+      test $(my-script 'some input') -eq 'some output'
     }
 
 To run the tests, simply:

--- a/bash-test
+++ b/bash-test
@@ -68,12 +68,20 @@ check_input_files "$@"
 time {
   display_header
 
+  original_path=$PATH
+
   for test_file in "$@"; do
-    # shellcheck source=/dev/null
     source "$test_file"
     basename "$test_file"
 
-    for test_name in $(get_loaded_tests); do
+    if [ -n "$SOURCE" ]; then
+      add_to_path="$(dirname "$test_file")/$SOURCE"
+      PATH=$add_to_path:$original_path
+    fi
+
+    test_names=$(get_loaded_tests)
+
+    for test_name in $test_names; do
       ((amount_of_tests++))
 
       $test_name
@@ -81,8 +89,11 @@ time {
 
       [ $result -ne 0 ] && ((failed_tests++))
       display_test_result $result "$test_name"
-      unset -f "$test_name"
     done
+
+    PATH=$original_path
+    unset -f $test_names
+    unset -v SOURCE
 
     echo ""
   done

--- a/test/support/local-script
+++ b/test/support/local-script
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo '42'

--- a/test/support/test-script-relative-path.sh
+++ b/test/support/test-script-relative-path.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export SOURCE='.'
+
+function test_using_a_local_script {
+  test $(local-script) -eq '42'
+}

--- a/test/test_bash-test.sh
+++ b/test/test_bash-test.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-curr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-function bash-test {
-  "$curr_dir/../bash-test" "$@"
-}
+export SOURCE=".."
 
 function exclude_header {
   echo "$1" | tail -n +3
@@ -36,6 +32,8 @@ function test_invalid_option_exits_with_code_1 {
   bash-test -z >/dev/null
   test $? -eq 1
 }
+
+curr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 function test_run_all_tests_present_on_input_file {
   expected=$(cat "$curr_dir"/support/sample-tests-1.expected_output.txt)
@@ -77,4 +75,9 @@ function test_invalid_input_file_displays_error_message {
 function test_invalid_input_file_exits_with_code_1 {
   bash-test "$curr_dir"/non/existent/file.sh >/dev/null 2>&1
   test $? -eq 1
+}
+
+function test_should_locate_scripts_according_to_relative_path {
+  bash-test "$curr_dir/support/test-script-relative-path.sh" >/dev/null 2>&1
+  test $? -eq 0
 }

--- a/test/test_bash-test.sh
+++ b/test/test_bash-test.sh
@@ -1,77 +1,80 @@
 #!/usr/bin/env bash
 
 curr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cmd="$curr_dir/../bash-test"
+
+function bash-test {
+  "$curr_dir/../bash-test" "$@"
+}
 
 function exclude_header {
   echo "$1" | tail -n +3
 }
 
 function test_help_option_displays_help {
-  $cmd -h | grep -q 'Usage'
+  bash-test -h | grep -q 'Usage'
 }
 
 function test_help_option_exits_with_code_0 {
-  $cmd -h >/dev/null
+  bash-test -h >/dev/null
   test $? -eq 0
 }
 
 function test_version_option_displays_version {
-  $cmd -v | grep -qE "v[0-9]+\.[0-9]+\.[0-9]+"
+  bash-test -v | grep -qE "v[0-9]+\.[0-9]+\.[0-9]+"
 }
 
 function test_version_option_exits_with_code_0 {
-  $cmd -v >/dev/null
+  bash-test -v >/dev/null
   test $? -eq 0
 }
 
 function test_invalid_option_displays_help {
-  $cmd -z | grep -q 'Usage'
+  bash-test -z | grep -q 'Usage'
 }
 
 function test_invalid_option_exits_with_code_1 {
-  $cmd -z >/dev/null
+  bash-test -z >/dev/null
   test $? -eq 1
 }
 
 function test_run_all_tests_present_on_input_file {
   expected=$(cat "$curr_dir"/support/sample-tests-1.expected_output.txt)
-  actual=$($cmd "$curr_dir"/support/sample-tests-1.sh 2>/dev/null)
+  actual=$(bash-test "$curr_dir"/support/sample-tests-1.sh 2>/dev/null)
   diff <(exclude_header "$actual") <(echo -e "$expected")
 }
 
 function test_accepts_multiple_input_files {
   expected=$(cat "$curr_dir"/support/multiple-files.expected_output.txt)
-  actual=$($cmd "$curr_dir"/support/*.sh 2>/dev/null)
+  actual=$(bash-test "$curr_dir"/support/sample-tests-*.sh 2>/dev/null)
   diff <(exclude_header "$actual") <(echo -e "$expected")
 }
 
 function test_elapsed_time_of_tests_execution_is_displayed {
-  actual=$($cmd "$curr_dir"/support/*.sh 2>&1 >/dev/null)
+  actual=$(bash-test "$curr_dir"/support/*.sh 2>&1 >/dev/null)
   echo "$actual" | grep -q "real" &&\
   echo "$actual" | grep -q "user" &&\
   echo "$actual" | grep -q "sys"
 }
 
 function test_all_tests_passing_exits_with_code_0 {
-  $cmd "$curr_dir"/support/sample-tests-2.sh >/dev/null 2>&1
+  bash-test "$curr_dir"/support/sample-tests-2.sh >/dev/null 2>&1
   test $? -eq 0
 }
 
 function test_at_least_one_test_failing_exits_with_code_greater_than_0 {
-  $cmd "$curr_dir"/support/*.sh >/dev/null 2>&1
+  bash-test "$curr_dir"/support/*.sh >/dev/null 2>&1
   test $? -gt 0
 }
 
 function test_invalid_input_file_displays_error_message {
   invalid_input_file="$curr_dir/non/existent/file.sh"
-  $cmd "$invalid_input_file" \
+  bash-test "$invalid_input_file" \
     | grep 'ERROR' \
     | grep 'Invalid input file' \
     | grep -q "$invalid_input_file"
 }
 
 function test_invalid_input_file_exits_with_code_1 {
-  $cmd "$curr_dir"/non/existent/file.sh >/dev/null 2>&1
+  bash-test "$curr_dir"/non/existent/file.sh >/dev/null 2>&1
   test $? -eq 1
 }


### PR DESCRIPTION
In this pull request I'm suggesting to export a variable from the test case scripts in order to have access to any script in the repository using relative paths, to avoid having to source them manually and to have better control over the execution of the tests.

This way, the tests will reflect better the real usage of the script under test. The location indicated in the variable is resolved to the respective absolute path and prepended to the `$PATH` temporarily, so it's possible to invoke the script directly.

Anyway, exporting this variable is optional (backwards compatible with old tests).

The existence of this variable exported from the test case will also allow a hook to do the instrumentation for potential code coverage solutions (which I already have some ideas in mind ;)